### PR TITLE
Add base directory and mount directory.

### DIFF
--- a/example.json
+++ b/example.json
@@ -24,7 +24,6 @@
         {
             "type": "wim",
             "image_name": "test-image",
-            "image_path": "test-image-dir",
             "image_description": "This is a test description"
         }
     ]


### PR DESCRIPTION
Base directory will be used store final artifact.
Mount directory to be used in later image creation actions.

Removed imagepath property from wim artifact
configuration. For now a default path will be in
artifact base directory which is called "wim".