### PR TITLE
Update build_windows.yml

### DIFF
--- a/.github/workflows/build_windows.yml
+++ b/.github/workflows/build_windows.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
     types:
       - opened
+      - synchronize
     branches:
       - "main"
       - "releases/**"


### PR DESCRIPTION
Add 'synchronize' type to allow github workflow to be rebuilded when there is a push to PR.