### PR TITLE
fixed installation issue

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,12 +5,14 @@ import (
 	"os"
 
 	"github.com/hashicorp/packer-plugin-sdk/plugin"
+	v "github.com/hashicorp/packer-plugin-sdk/version"
 	create "github.com/powa458/packer-plugin-wim/post-processor/create"
 )
 
 func main() {
 	pps := plugin.NewSet()
 	pps.RegisterPostProcessor(plugin.DEFAULT_NAME, new(create.PostProcessor))
+	pps.SetVersion(v.InitializePluginVersion("0.5.1", ""))
 	err := pps.Run()
 	if err != nil {
 		fmt.Fprintln(os.Stderr, err.Error())

--- a/release/packer-plugin-wim_v0.5.1_windows_amd64_SHA256SUMS
+++ b/release/packer-plugin-wim_v0.5.1_windows_amd64_SHA256SUMS
@@ -1,0 +1,1 @@
+c64d578d7538c93fca31bbbb30080f71277def406cc3c0f5f7554876bd403fb8  packer-plugin-wim_v0.5.1_x5.0_windows_amd64.zip


### PR DESCRIPTION
The plugin doesn't report its version so _packer plugins install -path packer-plugin-wim_windows_amd64.exe "hostname/namespace/name"_ will error out.

```
PS C:\temp> packer plugins install -path .\packer-plugin-wim_windows_amd64.exe "github.com/marmold/wim"
Error: Invalid version

Plugin's reported version ("") is not semver-compatible: Malformed version:
```
See below:
```
PS C:\temp> .\packer-plugin-wim_windows_amd64.exe describe
{"version":"","sdk_version":"0.2.3","api_version":"x5.0","builders":[],"post_processors":["-packer-default-plugin-name-"],"provisioners":[],"datasources":[]}
```

Fixed by implementing the version package from packer-plugin-sdk.